### PR TITLE
[#4] Add ESLint to lint the codebase

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
         run: npm ci
 
       - name: Run linters
-        run: npm run stylelint -workspaces
+        run: npm run lint --workspaces

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.16.7"
@@ -25,7 +24,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.16.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -33,7 +31,6 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.17.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -46,7 +43,6 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -57,7 +53,6 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -70,7 +65,6 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -78,12 +72,10 @@
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -91,7 +83,6 @@
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -100,10 +91,47 @@
         "node": ">=4"
       }
     },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.1",
+        "globals": "^13.9.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -1018,13 +1046,32 @@
         "node": ">= 10.18.0"
       }
     },
+    "node_modules/@nimblehq/eslint-config-nimble": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nimblehq/eslint-config-nimble/-/eslint-config-nimble-2.3.0.tgz",
+      "integrity": "sha512-o0AHIflsgKsgEhhYYwgBGOUvgwHU83Opil9cnATvZ7umyh+a4okyO3UhurdciS5CnKRik8rIvoAZwf1VSe/zDg==",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.18.0",
+        "@typescript-eslint/parser": "^5.18.0",
+        "eslint": "^8.12.0",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-cypress": "^2.12.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jest": "^26.1.3"
+      },
+      "engines": {
+        "node": "^14.18.2 || ^16 || ^17"
+      },
+      "peerDependencies": {
+        "eslint": "^8.12.0"
+      }
+    },
     "node_modules/@nimblehq/stylelint-config-nimble": {
       "resolved": "packages/stylelint-config-nimble",
       "link": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1036,7 +1083,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1044,7 +1090,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1304,6 +1349,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "dev": true,
@@ -1311,23 +1366,215 @@
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
+        "debug": "^4.3.2",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
+        "debug": "^4.3.2"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
+      "dependencies": {
+        "@typescript-eslint/utils": "5.20.0",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.20.0",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/add-stream": {
       "version": "1.0.0",
@@ -1372,7 +1619,6 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1401,7 +1647,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1409,7 +1654,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1462,6 +1706,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/array-differ": {
       "version": "3.0.0",
       "dev": true,
@@ -1475,17 +1724,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/array-includes": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/arrify": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1514,7 +1796,6 @@
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1548,7 +1829,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
@@ -1566,7 +1846,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1575,7 +1854,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -1640,7 +1918,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -1652,7 +1929,6 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1660,7 +1936,6 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1668,7 +1943,6 @@
     },
     "node_modules/camelcase-keys": {
       "version": "6.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -1689,7 +1963,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1791,7 +2064,6 @@
     },
     "node_modules/clone-regexp": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-regexp": "^2.0.0"
@@ -1821,7 +2093,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1832,12 +2103,10 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colord": {
       "version": "2.9.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/columnify": {
@@ -1885,7 +2154,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -2049,7 +2317,6 @@
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -2064,7 +2331,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2077,7 +2343,6 @@
     },
     "node_modules/css-functions-list": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.22"
@@ -2086,12 +2351,10 @@
     "node_modules/css-property-sort-order-smacss": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/css-property-sort-order-smacss/-/css-property-sort-order-smacss-2.2.0.tgz",
-      "integrity": "sha512-nXutswsivIEBOrPo/OZw2KQjFPLvtg68aovJf6Kqrm3L6FmTvvFPaeDrk83hh0+pRJGuP3PeKJwMS0E6DFipdQ==",
-      "dev": true
+      "integrity": "sha512-nXutswsivIEBOrPo/OZw2KQjFPLvtg68aovJf6Kqrm3L6FmTvvFPaeDrk83hh0+pRJGuP3PeKJwMS0E6DFipdQ=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -2129,7 +2392,6 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -2153,7 +2415,6 @@
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2161,7 +2422,6 @@
     },
     "node_modules/decamelize-keys": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "decamelize": "^1.1.0",
@@ -2173,7 +2433,6 @@
     },
     "node_modules/decamelize-keys/node_modules/map-obj": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2192,6 +2451,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
     "node_modules/defaults": {
       "version": "1.0.3",
       "dev": true,
@@ -2202,7 +2466,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-keys": "^1.0.12"
@@ -2256,13 +2519,23 @@
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dot-prop": {
@@ -2295,7 +2568,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding": {
@@ -2345,7 +2617,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -2353,7 +2624,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.19.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2384,9 +2654,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -2410,10 +2687,423 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "dependencies": {
+        "@eslint/eslintrc": "^1.2.1",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
+      "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "glob": "^7.2.0",
+        "is-glob": "^4.0.3",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-cypress": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
+      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "dependencies": {
+        "globals": "^11.12.0"
+      },
+      "peerDependencies": {
+        "eslint": ">= 3.2.1"
+      }
+    },
+    "node_modules/eslint-plugin-cypress/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "dependencies": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.3",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.5",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "26.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.4.tgz",
+      "integrity": "sha512-wgqxujmqc2qpvZqMFWCh6Cniqc8lWpapvXt9j/19DmBDqeDaYhJrSRezYR1SKyemvjx+9e9kny/dgRahraHImA==",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -2445,7 +3135,6 @@
     },
     "node_modules/execall": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-regexp": "^2.1.0"
@@ -2482,12 +3171,10 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2502,17 +3189,19 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.13.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2534,7 +3223,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -2545,7 +3233,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2564,7 +3251,6 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -2576,7 +3262,6 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -2588,7 +3273,6 @@
     },
     "node_modules/flatted": {
       "version": "3.2.5",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/forever-agent": {
@@ -2639,13 +3323,16 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "node_modules/gauge": {
       "version": "2.7.4",
@@ -2720,7 +3407,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -2797,7 +3483,6 @@
     },
     "node_modules/get-stdin": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2819,7 +3504,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2928,7 +3612,6 @@
     },
     "node_modules/glob": {
       "version": "7.2.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2947,7 +3630,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2958,7 +3640,6 @@
     },
     "node_modules/global-modules": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "global-prefix": "^3.0.0"
@@ -2969,7 +3650,6 @@
     },
     "node_modules/global-prefix": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ini": "^1.3.5",
@@ -2982,7 +3662,6 @@
     },
     "node_modules/global-prefix/node_modules/which": {
       "version": "1.3.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -2991,9 +3670,33 @@
         "which": "bin/which"
       }
     },
+    "node_modules/globals": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
@@ -3012,7 +3715,6 @@
     },
     "node_modules/globjoin": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/graceful-fs": {
@@ -3062,7 +3764,6 @@
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3070,7 +3771,6 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -3081,7 +3781,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3089,7 +3788,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3097,7 +3795,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3108,7 +3805,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -3127,7 +3823,6 @@
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3138,7 +3833,6 @@
     },
     "node_modules/html-tags": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3220,7 +3914,6 @@
     },
     "node_modules/ignore": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3236,7 +3929,6 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -3251,7 +3943,6 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3259,7 +3950,6 @@
     },
     "node_modules/import-lazy": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3285,7 +3975,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -3293,7 +3982,6 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3306,7 +3994,6 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -3315,12 +4002,10 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/init-package-json": {
@@ -3379,7 +4064,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.0",
@@ -3397,12 +4081,10 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -3413,7 +4095,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -3428,7 +4109,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3450,7 +4130,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
@@ -3461,7 +4140,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3475,7 +4153,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3483,7 +4160,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3491,7 +4167,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3507,7 +4182,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3518,7 +4192,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3526,7 +4199,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3548,7 +4220,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3556,7 +4227,6 @@
     },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3564,7 +4234,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -3579,7 +4248,6 @@
     },
     "node_modules/is-regexp": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3587,7 +4255,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -3617,7 +4284,6 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3631,7 +4297,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -3661,7 +4326,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -3677,7 +4341,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -3695,8 +4358,18 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
@@ -3710,7 +4383,6 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema": {
@@ -3720,13 +4392,28 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -3778,7 +4465,6 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3786,7 +4472,6 @@
     },
     "node_modules/known-css-properties": {
       "version": "0.24.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lerna": {
@@ -3818,6 +4503,18 @@
       },
       "engines": {
         "node": ">= 10.18.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/libnpmaccess": {
@@ -3961,7 +4658,6 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/load-json-file": {
@@ -3988,7 +4684,6 @@
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -3999,7 +4694,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
@@ -4011,6 +4705,11 @@
       "version": "4.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -4031,12 +4730,10 @@
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -4094,7 +4791,6 @@
     },
     "node_modules/map-obj": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4105,7 +4801,6 @@
     },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4224,7 +4919,6 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4232,7 +4926,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
@@ -4271,7 +4964,6 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4279,7 +4971,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4290,12 +4981,10 @@
     },
     "node_modules/minimist": {
       "version": "1.2.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arrify": "^1.0.1",
@@ -4432,7 +5121,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multimatch": {
@@ -4468,7 +5156,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.2",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -4476,6 +5163,11 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -4659,7 +5351,6 @@
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
@@ -4673,7 +5364,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4681,7 +5371,6 @@
     },
     "node_modules/normalize-selector": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-url": {
@@ -4860,7 +5549,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.12.0",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4868,7 +5556,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4876,7 +5563,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -4907,9 +5593,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.values": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4927,6 +5628,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/os-homedir": {
@@ -4964,7 +5681,6 @@
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -4978,7 +5694,6 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -5056,7 +5771,6 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5165,7 +5879,6 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -5176,7 +5889,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -5215,7 +5927,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5223,7 +5934,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5231,7 +5941,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5239,12 +5948,10 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5257,12 +5964,10 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5295,7 +6000,6 @@
     },
     "node_modules/postcss": {
       "version": "8.4.12",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5318,17 +6022,14 @@
     },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss-safe-parser": {
       "version": "6.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -5345,7 +6046,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
       "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-      "dev": true,
       "engines": {
         "node": ">=12.0"
       },
@@ -5359,7 +6059,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -5373,15 +6072,21 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
       "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
-      "dev": true,
       "peerDependencies": {
         "postcss": "^8.3.9"
       }
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -5430,7 +6135,6 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5478,7 +6182,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5497,7 +6200,6 @@
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5779,7 +6481,6 @@
     },
     "node_modules/redent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -5787,6 +6488,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/request": {
@@ -5837,7 +6549,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5845,7 +6556,6 @@
     },
     "node_modules/resolve": {
       "version": "1.22.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.8.1",
@@ -5872,7 +6582,6 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5900,7 +6609,6 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -5909,7 +6617,6 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -5931,7 +6638,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5988,7 +6694,6 @@
     },
     "node_modules/semver": {
       "version": "7.3.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^7.4.0"
@@ -6002,7 +6707,6 @@
     },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "7.7.3",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -6026,7 +6730,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6037,7 +6740,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6045,7 +6747,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -6058,12 +6759,10 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6071,7 +6770,6 @@
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6160,7 +6858,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6168,7 +6865,6 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -6177,12 +6873,10 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -6191,12 +6885,10 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.11",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/specificity": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "specificity": "bin/specificity"
@@ -6282,7 +6974,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6295,7 +6986,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6307,7 +6997,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6319,7 +7008,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6346,13 +7034,23 @@
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strong-log-transformer": {
@@ -6373,12 +7071,10 @@
     },
     "node_modules/style-search": {
       "version": "0.1.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/stylelint": {
       "version": "14.6.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^2.0.0",
@@ -6438,7 +7134,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-9.0.0.tgz",
       "integrity": "sha512-jQ1miJ6uQA+n6UkunhdhBmjFd5XCe/X7l9/yBI2KGdU+8+nYt1/7slHeLvsT7SCYByYqaLt9fUUCCOjyXH6PCw==",
-      "dev": true,
       "dependencies": {
         "css-property-sort-order-smacss": "~2.2.0",
         "stylelint-order": "^5.0.0"
@@ -6451,7 +7146,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-9.0.1.tgz",
       "integrity": "sha512-N06PsVsrgKijQ3YT5hqKA7x3NUkgELTRI1cbWMqcYiCGG6MjzvNk6Cb5YYA1PrvrksBV76BvY9P9bAswojVMqA==",
-      "dev": true,
       "dependencies": {
         "postcss-scss": "^4.0.2",
         "stylelint-order": "^5.0.0",
@@ -6469,7 +7163,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-5.0.0.tgz",
       "integrity": "sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==",
-      "dev": true,
       "dependencies": {
         "postcss": "^8.3.11",
         "postcss-sorting": "^7.0.1"
@@ -6482,7 +7175,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.2.0.tgz",
       "integrity": "sha512-HHHMVKJJ5RM9pPIbgJ/XA67h9H0407G68Rm69H4fzFbFkyDMcTV1Byep3qdze5+fJ3c0U7mJrbj6S0Fg072uZA==",
-      "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
         "postcss-media-query-parser": "^0.2.3",
@@ -6496,17 +7188,14 @@
     },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/stylelint/node_modules/meow": {
       "version": "9.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/minimist": "^1.2.0",
@@ -6531,7 +7220,6 @@
     },
     "node_modules/stylelint/node_modules/read-pkg": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
@@ -6545,7 +7233,6 @@
     },
     "node_modules/stylelint/node_modules/read-pkg-up": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.1.0",
@@ -6561,7 +7248,6 @@
     },
     "node_modules/stylelint/node_modules/read-pkg-up/node_modules/type-fest": {
       "version": "0.8.1",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -6569,7 +7255,6 @@
     },
     "node_modules/stylelint/node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -6580,7 +7265,6 @@
     },
     "node_modules/stylelint/node_modules/read-pkg/node_modules/type-fest": {
       "version": "0.6.0",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -6588,7 +7272,6 @@
     },
     "node_modules/stylelint/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -6596,7 +7279,6 @@
     },
     "node_modules/stylelint/node_modules/type-fest": {
       "version": "0.18.1",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -6607,7 +7289,6 @@
     },
     "node_modules/stylelint/node_modules/write-file-atomic": {
       "version": "4.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -6619,7 +7300,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6630,7 +7310,6 @@
     },
     "node_modules/supports-hyperlinks": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0",
@@ -6642,7 +7321,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6652,12 +7330,10 @@
       }
     },
     "node_modules/svg-tags": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "node_modules/table": {
       "version": "6.8.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
@@ -6672,7 +7348,6 @@
     },
     "node_modules/table/node_modules/ajv": {
       "version": "8.11.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -6687,7 +7362,6 @@
     },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tar": {
@@ -6737,6 +7411,11 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "dev": true,
@@ -6763,7 +7442,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6797,16 +7475,47 @@
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
-      "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -6823,6 +7532,17 @@
       "version": "0.14.5",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
@@ -6846,6 +7566,19 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/uglify-js": {
@@ -6875,7 +7608,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -6927,7 +7659,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -6935,7 +7666,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/util-promisify": {
@@ -6956,12 +7686,10 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -7020,7 +7748,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7034,7 +7761,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -7053,6 +7779,14 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {
@@ -7078,7 +7812,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -7231,12 +7964,10 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "1.10.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -7261,7 +7992,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "20.2.4",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7271,7 +8001,8 @@
       "name": "@nimblehq/stylelint-config-nimble",
       "version": "0.0.1",
       "license": "MIT",
-      "devDependencies": {
+      "dependencies": {
+        "@nimblehq/eslint-config-nimble": "^2.3.0",
         "stylelint": "^14.6.1",
         "stylelint-config-property-sort-order-smacss": "^9.0.0",
         "stylelint-config-sass-guidelines": "^9.0.1",
@@ -7289,18 +8020,15 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.16.7",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.16.7"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "dev": true
+      "version": "7.16.7"
     },
     "@babel/highlight": {
       "version": "7.17.9",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
@@ -7309,14 +8037,12 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
           "version": "2.4.2",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -7325,31 +8051,58 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
-          "version": "1.1.3",
-          "dev": true
+          "version": "1.1.3"
         },
         "has-flag": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "supports-color": {
           "version": "5.5.0",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
         }
       }
     },
+    "@eslint/eslintrc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.1",
+        "globals": "^13.9.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "dev": true
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -8024,31 +8777,43 @@
         "write-file-atomic": "^3.0.3"
       }
     },
+    "@nimblehq/eslint-config-nimble": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nimblehq/eslint-config-nimble/-/eslint-config-nimble-2.3.0.tgz",
+      "integrity": "sha512-o0AHIflsgKsgEhhYYwgBGOUvgwHU83Opil9cnATvZ7umyh+a4okyO3UhurdciS5CnKRik8rIvoAZwf1VSe/zDg==",
+      "requires": {
+        "@typescript-eslint/eslint-plugin": "^5.18.0",
+        "@typescript-eslint/parser": "^5.18.0",
+        "eslint": "^8.12.0",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-cypress": "^2.12.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jest": "^26.1.3"
+      }
+    },
     "@nimblehq/stylelint-config-nimble": {
       "version": "file:packages/stylelint-config-nimble",
       "requires": {
+        "@nimblehq/eslint-config-nimble": "*",
         "stylelint": "^14.6.1",
-        "stylelint-config-property-sort-order-smacss": "*",
-        "stylelint-config-sass-guidelines": "*",
-        "stylelint-order": "*",
-        "stylelint-scss": "*"
+        "stylelint-config-property-sort-order-smacss": "^9.0.0",
+        "stylelint-config-sass-guidelines": "^9.0.1",
+        "stylelint-order": "^5.0.0",
+        "stylelint-scss": "^4.2.0"
       }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -8250,25 +9015,130 @@
       "version": "1.1.2",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "dev": true
     },
     "@types/minimist": {
-      "version": "1.2.2",
-      "dev": true
+      "version": "1.2.2"
     },
     "@types/normalize-package-data": {
-      "version": "2.4.1",
-      "dev": true
+      "version": "2.4.1"
     },
     "@types/parse-json": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
+        "debug": "^4.3.2",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
+        "debug": "^4.3.2"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
+      "requires": {
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
+      "requires": {
+        "@typescript-eslint/utils": "5.20.0",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg=="
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
+      "requires": {
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
+      "requires": {
+        "@typescript-eslint/types": "5.20.0",
+        "eslint-visitor-keys": "^3.0.0"
+      }
     },
     "abbrev": {
       "version": "1.1.1",
       "dev": true
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "add-stream": {
       "version": "1.0.0",
@@ -8300,7 +9170,6 @@
     },
     "ajv": {
       "version": "6.12.6",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8316,12 +9185,10 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "dev": true
+      "version": "5.0.1"
     },
     "ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -8364,6 +9231,11 @@
         }
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "array-differ": {
       "version": "3.0.0",
       "dev": true
@@ -8372,13 +9244,34 @@
       "version": "1.0.0",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.7"
+      }
+    },
     "array-union": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
+    },
+    "array.prototype.flat": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
+      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      }
     },
     "arrify": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "asap": {
       "version": "2.0.6",
@@ -8396,8 +9289,7 @@
       "dev": true
     },
     "astral-regex": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "asynckit": {
       "version": "0.4.0",
@@ -8416,8 +9308,7 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -8432,7 +9323,6 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -8440,7 +9330,6 @@
     },
     "braces": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -8487,23 +9376,19 @@
     },
     "call-bind": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "camelcase": {
-      "version": "5.3.1",
-      "dev": true
+      "version": "5.3.1"
     },
     "camelcase-keys": {
       "version": "6.2.2",
-      "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
@@ -8516,7 +9401,6 @@
     },
     "chalk": {
       "version": "4.1.2",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -8582,7 +9466,6 @@
     },
     "clone-regexp": {
       "version": "2.2.0",
-      "dev": true,
       "requires": {
         "is-regexp": "^2.0.0"
       }
@@ -8600,18 +9483,15 @@
     },
     "color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "dev": true
+      "version": "1.1.4"
     },
     "colord": {
-      "version": "2.9.2",
-      "dev": true
+      "version": "2.9.2"
     },
     "columnify": {
       "version": "1.6.0",
@@ -8646,8 +9526,7 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -8764,7 +9643,6 @@
     },
     "cosmiconfig": {
       "version": "7.0.1",
-      "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -8775,7 +9653,6 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -8783,18 +9660,15 @@
       }
     },
     "css-functions-list": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "css-property-sort-order-smacss": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/css-property-sort-order-smacss/-/css-property-sort-order-smacss-2.2.0.tgz",
-      "integrity": "sha512-nXutswsivIEBOrPo/OZw2KQjFPLvtg68aovJf6Kqrm3L6FmTvvFPaeDrk83hh0+pRJGuP3PeKJwMS0E6DFipdQ==",
-      "dev": true
+      "integrity": "sha512-nXutswsivIEBOrPo/OZw2KQjFPLvtg68aovJf6Kqrm3L6FmTvvFPaeDrk83hh0+pRJGuP3PeKJwMS0E6DFipdQ=="
     },
     "cssesc": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "dargs": {
       "version": "7.0.0",
@@ -8813,7 +9687,6 @@
     },
     "debug": {
       "version": "4.3.4",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -8823,20 +9696,17 @@
       "dev": true
     },
     "decamelize": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
       },
       "dependencies": {
         "map-obj": {
-          "version": "1.0.1",
-          "dev": true
+          "version": "1.0.1"
         }
       }
     },
@@ -8848,6 +9718,11 @@
       "version": "0.7.0",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
     "defaults": {
       "version": "1.0.3",
       "dev": true,
@@ -8857,7 +9732,6 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -8892,9 +9766,16 @@
     },
     "dir-glob": {
       "version": "3.0.1",
-      "dev": true,
       "requires": {
         "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "dot-prop": {
@@ -8917,8 +9798,7 @@
       }
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "dev": true
+      "version": "8.0.0"
     },
     "encoding": {
       "version": "0.1.13",
@@ -8952,14 +9832,12 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
       "version": "1.19.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -8983,9 +9861,16 @@
         "unbox-primitive": "^1.0.1"
       }
     },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -8997,8 +9882,316 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
+    },
+    "eslint": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "requires": {
+        "@eslint/eslintrc": "^1.2.1",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        }
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "requires": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-import-resolver-typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
+      "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
+      "requires": {
+        "debug": "^4.3.4",
+        "glob": "^7.2.0",
+        "is-glob": "^4.0.3",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "requires": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
+      }
+    },
+    "eslint-plugin-cypress": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
+      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "requires": {
+        "globals": "^11.12.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.3",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.5",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "26.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.4.tgz",
+      "integrity": "sha512-wgqxujmqc2qpvZqMFWCh6Cniqc8lWpapvXt9j/19DmBDqeDaYhJrSRezYR1SKyemvjx+9e9kny/dgRahraHImA==",
+      "requires": {
+        "@typescript-eslint/utils": "^5.10.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+    },
+    "espree": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -9021,7 +10214,6 @@
     },
     "execall": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "clone-regexp": "^2.1.0"
       }
@@ -9044,12 +10236,10 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true
+      "version": "3.1.3"
     },
     "fast-glob": {
       "version": "3.2.11",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -9059,16 +10249,18 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastest-levenshtein": {
-      "version": "1.0.12",
-      "dev": true
+      "version": "1.0.12"
     },
     "fastq": {
       "version": "1.13.0",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -9082,14 +10274,12 @@
     },
     "file-entry-cache": {
       "version": "6.0.1",
-      "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
     },
     "fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -9100,7 +10290,6 @@
     },
     "find-up": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -9108,15 +10297,13 @@
     },
     "flat-cache": {
       "version": "3.0.4",
-      "dev": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "3.2.5",
-      "dev": true
+      "version": "3.2.5"
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -9149,12 +10336,15 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "function-bind": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gauge": {
       "version": "2.7.4",
@@ -9209,7 +10399,6 @@
     },
     "get-intrinsic": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -9265,8 +10454,7 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "8.0.0",
-      "dev": true
+      "version": "8.0.0"
     },
     "get-stream": {
       "version": "6.0.1",
@@ -9274,7 +10462,6 @@
     },
     "get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -9350,7 +10537,6 @@
     },
     "glob": {
       "version": "7.2.0",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -9362,21 +10548,18 @@
     },
     "glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
     },
     "global-modules": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "global-prefix": "^3.0.0"
       }
     },
     "global-prefix": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "ini": "^1.3.5",
         "kind-of": "^6.0.2",
@@ -9385,16 +10568,29 @@
       "dependencies": {
         "which": {
           "version": "1.3.1",
-          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         }
       }
     },
+    "globals": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
+      }
+    },
     "globby": {
       "version": "11.1.0",
-      "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -9405,8 +10601,7 @@
       }
     },
     "globjoin": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -9436,31 +10631,25 @@
       }
     },
     "hard-rejection": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "has": {
       "version": "1.0.3",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "has-flag": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -9471,14 +10660,12 @@
     },
     "hosted-git-info": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
     },
     "html-tags": {
-      "version": "3.2.0",
-      "dev": true
+      "version": "3.2.0"
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -9529,8 +10716,7 @@
       }
     },
     "ignore": {
-      "version": "5.2.0",
-      "dev": true
+      "version": "5.2.0"
     },
     "ignore-walk": {
       "version": "3.0.4",
@@ -9541,21 +10727,18 @@
     },
     "import-fresh": {
       "version": "3.3.0",
-      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       },
       "dependencies": {
         "resolve-from": {
-          "version": "4.0.0",
-          "dev": true
+          "version": "4.0.0"
         }
       }
     },
     "import-lazy": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "import-local": {
       "version": "3.1.0",
@@ -9566,12 +10749,10 @@
       }
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "indent-string": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -9579,19 +10760,16 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.4",
-      "dev": true
+      "version": "2.0.4"
     },
     "ini": {
-      "version": "1.3.8",
-      "dev": true
+      "version": "1.3.8"
     },
     "init-package-json": {
       "version": "2.0.5",
@@ -9639,7 +10817,6 @@
     },
     "internal-slot": {
       "version": "1.0.3",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -9651,27 +10828,23 @@
       "dev": true
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "is-bigint": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
     },
     "is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-callable": {
-      "version": "1.2.4",
-      "dev": true
+      "version": "1.2.4"
     },
     "is-ci": {
       "version": "2.0.0",
@@ -9682,29 +10855,24 @@
     },
     "is-core-module": {
       "version": "2.8.1",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-date-object": {
       "version": "1.0.5",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-extglob": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -9714,16 +10882,13 @@
       "dev": true
     },
     "is-negative-zero": {
-      "version": "2.0.2",
-      "dev": true
+      "version": "2.0.2"
     },
     "is-number": {
-      "version": "7.0.0",
-      "dev": true
+      "version": "7.0.0"
     },
     "is-number-object": {
       "version": "1.0.7",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -9733,28 +10898,23 @@
       "dev": true
     },
     "is-plain-obj": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "is-plain-object": {
-      "version": "5.0.0",
-      "dev": true
+      "version": "5.0.0"
     },
     "is-regex": {
       "version": "1.1.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-regexp": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -9772,14 +10932,12 @@
     },
     "is-string": {
       "version": "1.0.7",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-symbol": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -9797,7 +10955,6 @@
     },
     "is-weakref": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -9807,8 +10964,7 @@
       "dev": true
     },
     "isexe": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "isobject": {
       "version": "3.0.1",
@@ -9819,8 +10975,15 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -9831,20 +10994,31 @@
       "dev": true
     },
     "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "dev": true
+      "version": "2.3.1"
     },
     "json-schema": {
       "version": "0.4.0",
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "dev": true
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -9877,12 +11051,10 @@
       }
     },
     "kind-of": {
-      "version": "6.0.3",
-      "dev": true
+      "version": "6.0.3"
     },
     "known-css-properties": {
-      "version": "0.24.0",
-      "dev": true
+      "version": "0.24.0"
     },
     "lerna": {
       "version": "4.0.0",
@@ -9906,6 +11078,15 @@
         "@lerna/version": "4.0.0",
         "import-local": "^3.0.2",
         "npmlog": "^4.1.2"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "libnpmaccess": {
@@ -10020,8 +11201,7 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.2.4",
-      "dev": true
+      "version": "1.2.4"
     },
     "load-json-file": {
       "version": "6.2.0",
@@ -10041,14 +11221,12 @@
     },
     "locate-path": {
       "version": "5.0.0",
-      "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "dev": true
+      "version": "4.17.21"
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -10057,6 +11235,11 @@
     "lodash.ismatch": {
       "version": "4.4.0",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -10074,12 +11257,10 @@
       }
     },
     "lodash.truncate": {
-      "version": "4.4.2",
-      "dev": true
+      "version": "4.4.2"
     },
     "lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -10119,12 +11300,10 @@
       }
     },
     "map-obj": {
-      "version": "4.3.0",
-      "dev": true
+      "version": "4.3.0"
     },
     "mathml-tag-names": {
-      "version": "2.1.3",
-      "dev": true
+      "version": "2.1.3"
     },
     "meow": {
       "version": "8.1.2",
@@ -10203,12 +11382,10 @@
       "dev": true
     },
     "merge2": {
-      "version": "1.4.1",
-      "dev": true
+      "version": "1.4.1"
     },
     "micromatch": {
       "version": "4.0.5",
-      "dev": true,
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -10230,23 +11407,19 @@
       "dev": true
     },
     "min-indent": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "dev": true
+      "version": "1.2.6"
     },
     "minimist-options": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0",
@@ -10332,8 +11505,7 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.2",
-      "dev": true
+      "version": "2.1.2"
     },
     "multimatch": {
       "version": "5.0.0",
@@ -10357,8 +11529,12 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.2",
-      "dev": true
+      "version": "3.3.2"
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "negotiator": {
       "version": "0.6.3",
@@ -10490,7 +11666,6 @@
     },
     "normalize-package-data": {
       "version": "3.0.3",
-      "dev": true,
       "requires": {
         "hosted-git-info": "^4.0.1",
         "is-core-module": "^2.5.0",
@@ -10499,12 +11674,10 @@
       }
     },
     "normalize-path": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "normalize-selector": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -10628,16 +11801,13 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "dev": true
+      "version": "1.12.0"
     },
     "object-keys": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "object.assign": {
       "version": "4.1.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -10654,9 +11824,18 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "object.values": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -10666,6 +11845,19 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "os-homedir": {
@@ -10690,14 +11882,12 @@
     },
     "p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
     },
     "p-locate": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
       }
@@ -10737,8 +11927,7 @@
       }
     },
     "p-try": {
-      "version": "2.2.0",
-      "dev": true
+      "version": "2.2.0"
     },
     "p-waterfall": {
       "version": "2.1.1",
@@ -10819,14 +12008,12 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
     },
     "parse-json": {
       "version": "5.2.0",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -10855,36 +12042,29 @@
       }
     },
     "path-exists": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "path-key": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "path-parse": {
-      "version": "1.0.7",
-      "dev": true
+      "version": "1.0.7"
     },
     "path-type": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "performance-now": {
       "version": "2.1.0",
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "picomatch": {
-      "version": "2.3.1",
-      "dev": true
+      "version": "2.3.1"
     },
     "pify": {
       "version": "5.0.0",
@@ -10899,7 +12079,6 @@
     },
     "postcss": {
       "version": "8.4.12",
-      "dev": true,
       "requires": {
         "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
@@ -10907,28 +12086,23 @@
       }
     },
     "postcss-media-query-parser": {
-      "version": "0.2.3",
-      "dev": true
+      "version": "0.2.3"
     },
     "postcss-resolve-nested-selector": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "postcss-safe-parser": {
       "version": "6.0.0",
-      "dev": true,
       "requires": {}
     },
     "postcss-scss": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
       "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-      "dev": true,
       "requires": {}
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
-      "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10938,12 +12112,15 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
       "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
-      "dev": true,
       "requires": {}
     },
     "postcss-value-parser": {
-      "version": "4.2.0",
-      "dev": true
+      "version": "4.2.0"
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -10981,8 +12158,7 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "q": {
       "version": "1.5.1",
@@ -11006,12 +12182,10 @@
       }
     },
     "queue-microtask": {
-      "version": "1.2.3",
-      "dev": true
+      "version": "1.2.3"
     },
     "quick-lru": {
-      "version": "4.0.1",
-      "dev": true
+      "version": "4.0.1"
     },
     "read": {
       "version": "1.0.7",
@@ -11211,11 +12385,15 @@
     },
     "redent": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
     "request": {
       "version": "2.88.2",
@@ -11254,12 +12432,10 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "2.0.2",
-      "dev": true
+      "version": "2.0.2"
     },
     "resolve": {
       "version": "1.22.0",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -11274,8 +12450,7 @@
       }
     },
     "resolve-from": {
-      "version": "5.0.0",
-      "dev": true
+      "version": "5.0.0"
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -11290,12 +12465,10 @@
       "dev": true
     },
     "reusify": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "rimraf": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -11306,7 +12479,6 @@
     },
     "run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
@@ -11328,14 +12500,12 @@
     },
     "semver": {
       "version": "7.3.6",
-      "dev": true,
       "requires": {
         "lru-cache": "^7.4.0"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.7.3",
-          "dev": true
+          "version": "7.7.3"
         }
       }
     },
@@ -11352,18 +12522,15 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "side-channel": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -11371,16 +12538,13 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.7",
-      "dev": true
+      "version": "3.0.7"
     },
     "slash": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "slice-ansi": {
       "version": "4.0.0",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -11430,36 +12594,30 @@
       "dev": true
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "spdx-correct": {
       "version": "3.1.1",
-      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
-      "version": "2.3.0",
-      "dev": true
+      "version": "2.3.0"
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.11",
-      "dev": true
+      "version": "3.0.11"
     },
     "specificity": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
     },
     "split": {
       "version": "1.0.1",
@@ -11514,7 +12672,6 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11523,7 +12680,6 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -11531,7 +12687,6 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -11539,7 +12694,6 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -11554,10 +12708,14 @@
     },
     "strip-indent": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "strong-log-transformer": {
       "version": "2.1.0",
@@ -11569,12 +12727,10 @@
       }
     },
     "style-search": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "stylelint": {
       "version": "14.6.1",
-      "dev": true,
       "requires": {
         "balanced-match": "^2.0.0",
         "colord": "^2.9.2",
@@ -11620,16 +12776,13 @@
       },
       "dependencies": {
         "balanced-match": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "hosted-git-info": {
-          "version": "2.8.9",
-          "dev": true
+          "version": "2.8.9"
         },
         "meow": {
           "version": "9.0.0",
-          "dev": true,
           "requires": {
             "@types/minimist": "^1.2.0",
             "camelcase-keys": "^6.2.2",
@@ -11647,7 +12800,6 @@
         },
         "read-pkg": {
           "version": "5.2.0",
-          "dev": true,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
             "normalize-package-data": "^2.5.0",
@@ -11657,7 +12809,6 @@
           "dependencies": {
             "normalize-package-data": {
               "version": "2.5.0",
-              "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -11666,14 +12817,12 @@
               }
             },
             "type-fest": {
-              "version": "0.6.0",
-              "dev": true
+              "version": "0.6.0"
             }
           }
         },
         "read-pkg-up": {
           "version": "7.0.1",
-          "dev": true,
           "requires": {
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
@@ -11681,22 +12830,18 @@
           },
           "dependencies": {
             "type-fest": {
-              "version": "0.8.1",
-              "dev": true
+              "version": "0.8.1"
             }
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "dev": true
+          "version": "5.7.1"
         },
         "type-fest": {
-          "version": "0.18.1",
-          "dev": true
+          "version": "0.18.1"
         },
         "write-file-atomic": {
           "version": "4.0.1",
-          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "signal-exit": "^3.0.7"
@@ -11708,7 +12853,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-9.0.0.tgz",
       "integrity": "sha512-jQ1miJ6uQA+n6UkunhdhBmjFd5XCe/X7l9/yBI2KGdU+8+nYt1/7slHeLvsT7SCYByYqaLt9fUUCCOjyXH6PCw==",
-      "dev": true,
       "requires": {
         "css-property-sort-order-smacss": "~2.2.0",
         "stylelint-order": "^5.0.0"
@@ -11718,7 +12862,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-9.0.1.tgz",
       "integrity": "sha512-N06PsVsrgKijQ3YT5hqKA7x3NUkgELTRI1cbWMqcYiCGG6MjzvNk6Cb5YYA1PrvrksBV76BvY9P9bAswojVMqA==",
-      "dev": true,
       "requires": {
         "postcss-scss": "^4.0.2",
         "stylelint-order": "^5.0.0",
@@ -11729,7 +12872,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-5.0.0.tgz",
       "integrity": "sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==",
-      "dev": true,
       "requires": {
         "postcss": "^8.3.11",
         "postcss-sorting": "^7.0.1"
@@ -11739,7 +12881,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.2.0.tgz",
       "integrity": "sha512-HHHMVKJJ5RM9pPIbgJ/XA67h9H0407G68Rm69H4fzFbFkyDMcTV1Byep3qdze5+fJ3c0U7mJrbj6S0Fg072uZA==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.21",
         "postcss-media-query-parser": "^0.2.3",
@@ -11750,30 +12891,25 @@
     },
     "supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
     },
     "supports-hyperlinks": {
       "version": "2.2.0",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       }
     },
     "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "svg-tags": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "table": {
       "version": "6.8.0",
-      "dev": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -11784,7 +12920,6 @@
       "dependencies": {
         "ajv": {
           "version": "8.11.0",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -11793,8 +12928,7 @@
           }
         },
         "json-schema-traverse": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         }
       }
     },
@@ -11829,6 +12963,11 @@
       "version": "1.9.0",
       "dev": true
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
     "through": {
       "version": "2.3.8",
       "dev": true
@@ -11849,7 +12988,6 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -11870,12 +13008,36 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
+    },
+    "tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
+      }
     },
     "tslib": {
-      "version": "1.14.1",
-      "dev": true
+      "version": "1.14.1"
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -11887,6 +13049,14 @@
     "tweetnacl": {
       "version": "0.14.5",
       "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
     },
     "type-fest": {
       "version": "0.21.3",
@@ -11903,6 +13073,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "peer": true
+    },
     "uglify-js": {
       "version": "3.15.3",
       "dev": true,
@@ -11918,7 +13094,6 @@
     },
     "unbox-primitive": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -11954,14 +13129,12 @@
     },
     "uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "util-promisify": {
       "version": "2.1.0",
@@ -11975,12 +13148,10 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.3.0",
-      "dev": true
+      "version": "2.3.0"
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -12024,14 +13195,12 @@
     },
     "which": {
       "version": "2.0.2",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -12047,6 +13216,11 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
     "wordwrap": {
       "version": "1.0.0",
       "dev": true
@@ -12061,8 +13235,7 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -12164,12 +13337,10 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "yaml": {
-      "version": "1.10.2",
-      "dev": true
+      "version": "1.10.2"
     },
     "yargs": {
       "version": "16.2.0",
@@ -12185,8 +13356,7 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "dev": true
+      "version": "20.2.4"
     }
   }
 }

--- a/packages/stylelint-config-nimble/.eslintrc.js
+++ b/packages/stylelint-config-nimble/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@nimblehq/eslint-config-nimble'],
+  rules: {
+    '@typescript-eslint/no-var-requires': 'off',
+  },
+};

--- a/packages/stylelint-config-nimble/lib/index.js
+++ b/packages/stylelint-config-nimble/lib/index.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   extends: [
-    './rules/base'
+    './rules/base',
   ].map(require.resolve),
 };

--- a/packages/stylelint-config-nimble/lib/rules/base.js
+++ b/packages/stylelint-config-nimble/lib/rules/base.js
@@ -1,4 +1,4 @@
-const sortOrderSmacss = require('stylelint-config-property-sort-order-smacss/generate')
+const sortOrderSmacss = require('stylelint-config-property-sort-order-smacss/generate');
 
 module.exports = {
   plugins: ['stylelint-scss', 'stylelint-order'],
@@ -8,5 +8,5 @@ module.exports = {
     'max-nesting-depth': 3,
     'order/properties-alphabetical-order': null,
     'order/properties-order': [sortOrderSmacss({ emptyLineBefore: 'always' })],
-  }
-}
+  },
+};

--- a/packages/stylelint-config-nimble/package.json
+++ b/packages/stylelint-config-nimble/package.json
@@ -9,7 +9,8 @@
   ],
   "author": "Nimble",
   "main": "lib/index.js",
-  "devDependencies": {
+  "dependencies": {
+    "@nimblehq/eslint-config-nimble": "^2.3.0",
     "stylelint": "^14.6.1",
     "stylelint-config-property-sort-order-smacss": "^9.0.0",
     "stylelint-config-sass-guidelines": "^9.0.1",
@@ -20,8 +21,11 @@
     "stylelint": "^14.6.1"
   },
   "scripts": {
+    "eslint": "eslint .",
+    "eslint:fix": "eslint . --fix",
     "stylelint": "stylelint '**/*.{css,scss}'",
-    "stylelint:fix": "stylelint '**/*.{css,scss}' --fix"
+    "stylelint:fix": "stylelint '**/*.{css,scss}' --fix",
+    "lint": "npm run eslint && npm run stylelint"
   },
   "license": "MIT",
   "directories": {


### PR DESCRIPTION
Resolve https://github.com/nimblehq/stylelint-config-nimble/issues/4

## What happened 👀

- Add `@nimblehq/eslint-config-nimble` to lint the codebase
- Turn `@typescript-eslint/no-var-requires` off as we are using `javascript` files on this project
- Change `devDependencies` packages to `dependencies`, this allows this package can download the dependencies

## Insight 📝

N/A

## Proof Of Work 📹

Tests should be passed
