### PR TITLE
[#8] Update the publishing information and add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish packages to npmjs
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Publish packages
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node and restore cached dependencies
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@nimblehq"
+
+      - name: Install dependencies
+        run: npm ci && lerna bootstrap --ci
+
+      - name: Publish packages to npmjs
+        run: npx lerna publish from-package --yes --no-verify-access
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   release:
     types:
       - published
-  push:
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  push:
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -29,13 +29,11 @@ __Usage information is in the packages' documentation.__
 
 ### Publish packages
 
-Use [`lerna publish`](https://github.com/lerna/lerna/tree/main/commands/publish#readme) command to publish packages.
+- Packages will be published to npmjs automatically after publishing a new release.
 
-```bash
-  lerna publish
-```
+- Need to set the version in `/packages/**/package.json` before creating the release.
 
-_The current branch that you run the publish command should be pushed on Github._
+- More details in [publish workflow](/.github/workflows/publish.yml). This workflow uses [`lerna publish`](https://github.com/lerna/lerna/tree/main/commands/publish#readme) command to publish packages.
 
 ### Run commands
 

--- a/packages/stylelint-config-nimble/package.json
+++ b/packages/stylelint-config-nimble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/stylelint-config-nimble",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "description": "Stylelint base configuration developed and maintained by Nimble",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
Resolves https://github.com/nimblehq/stylelint-config-nimble/issues/8

## What happened 👀

- Update README to have publishing information
- Add `publish` workflow to publish packages automatically

## Insight 📝

- Follow https://github.com/nimblehq/react-templates/pull/114
- Just change to use `NODE_AUTH_TOKEN` env as `actions/setup-node@v3` [support it directly](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry).

## Proof Of Work 📹

Tested in https://github.com/nimblehq/stylelint-config-nimble/pull/9/commits/da6284d39d40eda16627876be4fcd537b65031ed
