### PR TITLE
Support Node >= 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9102,7 +9102,8 @@
       }
     },
     "packages/stylelint-config-nimble": {
-      "version": "1.0.1",
+      "name": "@nimblehq/stylelint-config-nimble",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@nimblehq/eslint-config-nimble-core": "^2.6.0",
@@ -9113,7 +9114,7 @@
         "stylelint-scss": "^4.2.0"
       },
       "engines": {
-        "node": "^16 || ^17 || ^18"
+        "node": ">=16"
       },
       "peerDependencies": {
         "stylelint": "^14.6.1"

--- a/packages/stylelint-config-nimble/package.json
+++ b/packages/stylelint-config-nimble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/stylelint-config-nimble",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Stylelint base configuration developed and maintained by Nimble",
   "keywords": [
     "stylelint",
@@ -32,7 +32,7 @@
     "lib": "lib"
   },
   "engines": {
-    "node": "^16 || ^17 || ^18"
+    "node": ">=16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What happened 👀

Change to support Node `>=16.0.0` instead, then later we don't need to update this.

## Insight 📝

If there is an issue later, we can re-check and add another PR to update

## Proof Of Work 📹

N/A
